### PR TITLE
feat: fix intherited indexed properties

### DIFF
--- a/files/2-finalized/awaited-dom/base/interfaces/isolate.ts
+++ b/files/2-finalized/awaited-dom/base/interfaces/isolate.ts
@@ -256,6 +256,9 @@ export interface IDocumentTypeIsolate {
 
 export interface IRadioNodeListIsolate {
   readonly value: Promise<string>;
+
+
+  [index: number]: ISuperNode;
 }
 
 // NodeListIsolate //////////
@@ -296,6 +299,8 @@ export interface IHTMLCollectionIsolate {
   namedItem(name: string): ISuperElement;
 
 
+
+  [index: number]: ISuperElement;
 }
 
 // CSSStyleSheetIsolate //////////

--- a/files/2-finalized/awaited-dom/base/interfaces/official.ts
+++ b/files/2-finalized/awaited-dom/base/interfaces/official.ts
@@ -483,6 +483,8 @@ export interface IHTMLCollection extends IHTMLCollectionBase {
   namedItem(name: string): ISuperElement;
 
 
+
+  [index: number]: ISuperElement;
 }
 
 // HTMLCollectionBase //////////
@@ -507,6 +509,8 @@ export interface IHTMLFormControlsCollection extends IHTMLCollectionBase {
   namedItem(name: string): Promise<IRadioNodeList | ISuperElement | null>;
 
 
+
+  [index: number]: ISuperElement;
 }
 
 // HTMLHyperlinkElementUtils //////////
@@ -803,6 +807,9 @@ export interface IParentNode {
 
 export interface IRadioNodeList extends INodeList {
   readonly value: Promise<string>;
+
+
+  [index: number]: ISuperNode;
 }
 
 // Range //////////

--- a/files/2-finalized/awaited-dom/base/interfaces/super.ts
+++ b/files/2-finalized/awaited-dom/base/interfaces/super.ts
@@ -93,6 +93,10 @@ export interface ISuperElement extends IElementCSSInlineStyle, IElementContentEd
   requestFullscreen(options?: IFullscreenOptions): Promise<void>;
   requestPointerLock(): Promise<void>;
   scrollIntoView(arg?: boolean | IScrollIntoViewOptions): Promise<void>;
+
+
+
+  [index: number]: ISuperElement;
 }
 
 // SuperNode //////////
@@ -142,6 +146,10 @@ export interface ISuperNode extends IAttrIsolate, ICharacterDataIsolate, IDocume
   lookupNamespaceURI(prefix: string | null): Promise<string | null>;
   lookupPrefix(namespace: string | null): Promise<string | null>;
   normalize(): Promise<void>;
+
+
+
+  [index: number]: ISuperElement;
 }
 
 // SuperNodeList //////////
@@ -166,6 +174,8 @@ export interface ISuperHTMLCollection extends IHTMLCollectionBaseIsolate, IHTMLC
   namedItem(name: string): ISuperElement;
 
   [Symbol.iterator](): Iterator<ISuperElement>;
+
+  [index: number]: ISuperElement;
 }
 
 // SuperText //////////
@@ -205,6 +215,10 @@ export interface ISuperHTMLElement extends IElementCSSInlineStyle, IElementConte
   readonly translate: Promise<boolean>;
 
   click(): Promise<void>;
+
+
+
+  [index: number]: ISuperElement;
 }
 
 // SVG ELEMENTS

--- a/files/2-finalized/awaited-dom/base/isolate-mixins/HTMLCollectionIsolate.ts
+++ b/files/2-finalized/awaited-dom/base/isolate-mixins/HTMLCollectionIsolate.ts
@@ -14,6 +14,8 @@ export default class HTMLCollectionIsolate implements IHTMLCollectionIsolate {
   }
 
 
+
+  [index: number]: ISuperElement;
 }
 
 // INTERFACES RELATED TO STATE MACHINE PROPERTIES ////////////////////////////

--- a/files/2-finalized/awaited-dom/base/isolate-mixins/HTMLOptionsCollectionIsolate.ts
+++ b/files/2-finalized/awaited-dom/base/isolate-mixins/HTMLOptionsCollectionIsolate.ts
@@ -2,6 +2,7 @@ import AwaitedHandler from '../AwaitedHandler';
 import StateMachine from '../StateMachine';
 import AwaitedPath from '../AwaitedPath';
 import { IHTMLOptionsCollectionIsolate } from '../interfaces/isolate';
+import { ISuperElement } from '../interfaces/super';
 
 // tslint:disable:variable-name
 export const { getState, setState } = StateMachine<IHTMLOptionsCollectionIsolate, IHTMLOptionsCollectionIsolateProperties>();

--- a/files/2-finalized/awaited-dom/base/isolate-mixins/HTMLSelectElementIsolate.ts
+++ b/files/2-finalized/awaited-dom/base/isolate-mixins/HTMLSelectElementIsolate.ts
@@ -3,8 +3,8 @@ import StateMachine from '../StateMachine';
 import AwaitedPath from '../AwaitedPath';
 import AwaitedIterator from '../AwaitedIterator';
 import { IHTMLSelectElementIsolate } from '../interfaces/isolate';
+import { ISuperElement, ISuperNodeList, ISuperHTMLCollection } from '../interfaces/super';
 import { IHTMLFormElement, IHTMLOptionsCollection, IValidityState, IHTMLOptionElement } from '../interfaces/official';
-import { ISuperNodeList, ISuperHTMLCollection, ISuperElement } from '../interfaces/super';
 
 // tslint:disable:variable-name
 export const { getState, setState } = StateMachine<IHTMLSelectElementIsolate, IHTMLSelectElementIsolateProperties>();

--- a/files/2-finalized/awaited-dom/base/isolate-mixins/RadioNodeListIsolate.ts
+++ b/files/2-finalized/awaited-dom/base/isolate-mixins/RadioNodeListIsolate.ts
@@ -2,6 +2,7 @@ import AwaitedHandler from '../AwaitedHandler';
 import StateMachine from '../StateMachine';
 import AwaitedPath from '../AwaitedPath';
 import { IRadioNodeListIsolate } from '../interfaces/isolate';
+import { ISuperNode } from '../interfaces/super';
 
 // tslint:disable:variable-name
 export const { getState, setState } = StateMachine<IRadioNodeListIsolate, IRadioNodeListIsolateProperties>();
@@ -11,6 +12,9 @@ export default class RadioNodeListIsolate implements IRadioNodeListIsolate {
   public get value(): Promise<string> {
     return awaitedHandler.getProperty<string>(this, 'value', false);
   }
+
+
+  [index: number]: ISuperNode;
 }
 
 // INTERFACES RELATED TO STATE MACHINE PROPERTIES ////////////////////////////

--- a/files/2-finalized/awaited-dom/base/official-klasses/HTMLCollection.ts
+++ b/files/2-finalized/awaited-dom/base/official-klasses/HTMLCollection.ts
@@ -25,6 +25,12 @@ export function HTMLCollectionGenerator(HTMLCollectionBase: Constructable<IHTMLC
             return value;
           }
 
+          // delegate to indexer property
+          if ((typeof prop === 'string' || typeof prop === 'number') && !isNaN(prop as unknown as number)) {
+            const param = parseInt(prop as string, 10);
+            return target.item(param);
+          }
+
           // delegate to string indexer
           if(typeof prop === 'string') {
             return target.namedItem(prop as string);
@@ -42,6 +48,8 @@ export function HTMLCollectionGenerator(HTMLCollectionBase: Constructable<IHTMLC
     }
 
 
+
+    [index: number]: ISuperElement;
 
     public [Symbol.for('nodejs.util.inspect.custom')]() {
       return inspectInstanceProperties(this, HTMLCollectionPropertyKeys, HTMLCollectionConstantKeys);

--- a/files/2-finalized/awaited-dom/base/official-klasses/HTMLFormControlsCollection.ts
+++ b/files/2-finalized/awaited-dom/base/official-klasses/HTMLFormControlsCollection.ts
@@ -25,6 +25,12 @@ export function HTMLFormControlsCollectionGenerator(HTMLCollectionBase: Construc
             return value;
           }
 
+          // delegate to indexer property
+          if ((typeof prop === 'string' || typeof prop === 'number') && !isNaN(prop as unknown as number)) {
+            const param = parseInt(prop as string, 10);
+            return target.item(param);
+          }
+
           // delegate to string indexer
           if(typeof prop === 'string') {
             return target.namedItem(prop as string);
@@ -42,6 +48,8 @@ export function HTMLFormControlsCollectionGenerator(HTMLCollectionBase: Construc
     }
 
 
+
+    [index: number]: ISuperElement;
 
     public [Symbol.for('nodejs.util.inspect.custom')]() {
       return inspectInstanceProperties(this, HTMLFormControlsCollectionPropertyKeys, HTMLFormControlsCollectionConstantKeys);

--- a/files/2-finalized/awaited-dom/base/official-klasses/HTMLSelectElement.ts
+++ b/files/2-finalized/awaited-dom/base/official-klasses/HTMLSelectElement.ts
@@ -6,7 +6,7 @@ import Constructable from '../Constructable';
 import AwaitedIterator from '../AwaitedIterator';
 import NodeFactory from '../NodeFactory';
 import { IHTMLSelectElement, IHTMLElement, IHTMLFormElement, IHTMLOptionsCollection, IValidityState, IHTMLOptionElement } from '../interfaces/official';
-import { ISuperNodeList, ISuperHTMLCollection, ISuperElement } from '../interfaces/super';
+import { ISuperElement, ISuperNodeList, ISuperHTMLCollection } from '../interfaces/super';
 import { IHTMLElementProperties, HTMLElementPropertyKeys, HTMLElementConstantKeys } from './HTMLElement';
 
 // tslint:disable:variable-name

--- a/files/2-finalized/awaited-dom/base/super-klasses/SuperHTMLCollection.ts
+++ b/files/2-finalized/awaited-dom/base/super-klasses/SuperHTMLCollection.ts
@@ -38,6 +38,12 @@ export function SuperHTMLCollectionGenerator(HTMLCollectionBaseIsolate: Construc
             return value;
           }
 
+          // delegate to indexer property
+          if ((typeof prop === 'string' || typeof prop === 'number') && !isNaN(prop as unknown as number)) {
+            const param = parseInt(prop as string, 10);
+            return target.item(param);
+          }
+
           // delegate to string indexer
           if(typeof prop === 'string') {
             return target.namedItem(prop as string);
@@ -61,6 +67,8 @@ export function SuperHTMLCollectionGenerator(HTMLCollectionBaseIsolate: Construc
     public [Symbol.iterator](): Iterator<ISuperElement> {
       return awaitedIterator.iterateNodePointers(this);
     }
+
+    [index: number]: ISuperElement;
 
     public [Symbol.for('nodejs.util.inspect.custom')]() {
       return inspectInstanceProperties(this, SuperHTMLCollectionPropertyKeys, SuperHTMLCollectionConstantKeys);

--- a/files/2-finalized/awaited-dom/base/super-klasses/SuperHTMLElement.ts
+++ b/files/2-finalized/awaited-dom/base/super-klasses/SuperHTMLElement.ts
@@ -99,6 +99,25 @@ export function SuperHTMLElementGenerator(ElementCSSInlineStyle: Constructable<I
       setState(this, {
         createInstanceName: 'createSuperHTMLElement',
       });
+      // proxy supports indexed property access
+      const proxy = new Proxy(this, {
+        get(target, prop) {
+          if (prop in target) {
+            // @ts-ignore
+            const value: any = target[prop];
+            if (typeof value === 'function') return value.bind(target);
+            return value;
+          }
+
+          // delegate to indexer property
+          if ((typeof prop === 'string' || typeof prop === 'number') && !isNaN(prop as unknown as number)) {
+            const param = parseInt(prop as string, 10);
+            return target.item(param);
+          }
+        },
+      });
+
+      return proxy;
     }
 
     // properties
@@ -176,6 +195,10 @@ export function SuperHTMLElementGenerator(ElementCSSInlineStyle: Constructable<I
     public then<TResult1 = ISuperHTMLElement, TResult2 = never>(onfulfilled?: ((value: ISuperHTMLElement) => (PromiseLike<TResult1> | TResult1)) | undefined | null, onrejected?: ((reason: any) => (PromiseLike<TResult2> | TResult2)) | undefined | null): Promise<TResult1 | TResult2> {
       return nodeFactory.createInstanceWithNodePointer(this).then(onfulfilled, onrejected);
     }
+
+
+
+    [index: number]: ISuperElement;
 
     public [Symbol.for('nodejs.util.inspect.custom')]() {
       return inspectInstanceProperties(this, SuperHTMLElementPropertyKeys, SuperHTMLElementConstantKeys);

--- a/files/2-finalized/awaited-dom/impl/isolate-mixins/HTMLOptionsCollectionIsolate.ts
+++ b/files/2-finalized/awaited-dom/impl/isolate-mixins/HTMLOptionsCollectionIsolate.ts
@@ -1,5 +1,6 @@
 import StateMachine from '../../base/StateMachine';
 import { IHTMLOptionsCollectionIsolate } from '../../base/interfaces/isolate';
+import { ISuperElement } from '../../base/interfaces/super';
 import HTMLOptionsCollectionIsolateBase, { IHTMLOptionsCollectionIsolateProperties } from '../../base/isolate-mixins/HTMLOptionsCollectionIsolate';
 
 // tslint:disable:variable-name

--- a/files/2-finalized/awaited-dom/impl/isolate-mixins/HTMLSelectElementIsolate.ts
+++ b/files/2-finalized/awaited-dom/impl/isolate-mixins/HTMLSelectElementIsolate.ts
@@ -1,7 +1,7 @@
 import StateMachine from '../../base/StateMachine';
 import { IHTMLSelectElementIsolate } from '../../base/interfaces/isolate';
+import { ISuperElement, ISuperNodeList, ISuperHTMLCollection } from '../../base/interfaces/super';
 import { IHTMLFormElement, IHTMLOptionsCollection, IHTMLOptionElement } from '../../base/interfaces/official';
-import { ISuperNodeList, ISuperHTMLCollection, ISuperElement } from '../../base/interfaces/super';
 import HTMLSelectElementIsolateBase, { IHTMLSelectElementIsolateProperties } from '../../base/isolate-mixins/HTMLSelectElementIsolate';
 import { createHTMLFormElement, createSuperNodeList, createHTMLOptionsCollection, createSuperHTMLCollection, createSuperElement, createHTMLOptionElement } from '../create';
 

--- a/files/2-finalized/awaited-dom/impl/isolate-mixins/RadioNodeListIsolate.ts
+++ b/files/2-finalized/awaited-dom/impl/isolate-mixins/RadioNodeListIsolate.ts
@@ -1,5 +1,6 @@
 import StateMachine from '../../base/StateMachine';
 import { IRadioNodeListIsolate } from '../../base/interfaces/isolate';
+import { ISuperNode } from '../../base/interfaces/super';
 import RadioNodeListIsolateBase, { IRadioNodeListIsolateProperties } from '../../base/isolate-mixins/RadioNodeListIsolate';
 
 // tslint:disable:variable-name

--- a/files/2-finalized/awaited-dom/impl/official-klasses/HTMLFormControlsCollection.ts
+++ b/files/2-finalized/awaited-dom/impl/official-klasses/HTMLFormControlsCollection.ts
@@ -1,5 +1,6 @@
 import StateMachine from '../../base/StateMachine';
-import { IHTMLFormControlsCollection } from '../../base/interfaces/official';
+import { IHTMLFormControlsCollection, IRadioNodeList } from '../../base/interfaces/official';
+import { ISuperElement } from '../../base/interfaces/super';
 import { HTMLFormControlsCollectionGenerator, IHTMLFormControlsCollectionProperties } from '../../base/official-klasses/HTMLFormControlsCollection';
 import HTMLCollectionBase from './HTMLCollectionBase';
 

--- a/files/2-finalized/awaited-dom/impl/official-klasses/HTMLOptionsCollection.ts
+++ b/files/2-finalized/awaited-dom/impl/official-klasses/HTMLOptionsCollection.ts
@@ -1,5 +1,6 @@
 import StateMachine from '../../base/StateMachine';
 import { IHTMLOptionsCollection } from '../../base/interfaces/official';
+import { ISuperElement } from '../../base/interfaces/super';
 import { HTMLOptionsCollectionGenerator, IHTMLOptionsCollectionProperties } from '../../base/official-klasses/HTMLOptionsCollection';
 import HTMLCollection from './HTMLCollection';
 

--- a/files/2-finalized/awaited-dom/impl/official-klasses/HTMLSelectElement.ts
+++ b/files/2-finalized/awaited-dom/impl/official-klasses/HTMLSelectElement.ts
@@ -1,6 +1,6 @@
 import StateMachine from '../../base/StateMachine';
 import { IHTMLSelectElement, IHTMLFormElement, IHTMLOptionsCollection, IHTMLOptionElement } from '../../base/interfaces/official';
-import { ISuperNodeList, ISuperHTMLCollection, ISuperElement } from '../../base/interfaces/super';
+import { ISuperElement, ISuperNodeList, ISuperHTMLCollection } from '../../base/interfaces/super';
 import { HTMLSelectElementGenerator, IHTMLSelectElementProperties } from '../../base/official-klasses/HTMLSelectElement';
 import { createHTMLFormElement, createSuperNodeList, createHTMLOptionsCollection, createSuperHTMLCollection, createSuperElement, createHTMLOptionElement } from '../create';
 import HTMLElement from './HTMLElement';

--- a/files/2-finalized/awaited-dom/impl/official-klasses/NamedNodeMap.ts
+++ b/files/2-finalized/awaited-dom/impl/official-klasses/NamedNodeMap.ts
@@ -1,5 +1,5 @@
 import StateMachine from '../../base/StateMachine';
-import { INamedNodeMap } from '../../base/interfaces/official';
+import { INamedNodeMap, IAttr } from '../../base/interfaces/official';
 import { NamedNodeMapGenerator, INamedNodeMapProperties } from '../../base/official-klasses/NamedNodeMap';
 
 // tslint:disable:variable-name

--- a/files/2-finalized/awaited-dom/impl/official-klasses/RadioNodeList.ts
+++ b/files/2-finalized/awaited-dom/impl/official-klasses/RadioNodeList.ts
@@ -1,5 +1,6 @@
 import StateMachine from '../../base/StateMachine';
 import { IRadioNodeList } from '../../base/interfaces/official';
+import { ISuperNode } from '../../base/interfaces/super';
 import { RadioNodeListGenerator, IRadioNodeListProperties } from '../../base/official-klasses/RadioNodeList';
 import NodeList from './NodeList';
 

--- a/files/2-finalized/awaited-dom/impl/super-klasses/SuperNode.ts
+++ b/files/2-finalized/awaited-dom/impl/super-klasses/SuperNode.ts
@@ -1,5 +1,5 @@
 import StateMachine from '../../base/StateMachine';
-import { ISuperNode, ISuperNodeList, ISuperDocument, ISuperElement } from '../../base/interfaces/super';
+import { ISuperNode, ISuperElement, ISuperNodeList, ISuperDocument } from '../../base/interfaces/super';
 import { IGetRootNodeOptions } from '../../base/interfaces/official';
 import { SuperNodeGenerator, ISuperNodeProperties } from '../../base/super-klasses/SuperNode';
 import { createSuperNodeList, createSuperNode, createSuperDocument, createSuperElement } from '../create';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noderdom",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Library for converting WebIDLs to Typescript interfaces and classes",
   "homepage": "https://github.com/ulixee/noderdom",
   "author": "Data Liberation Foundation",


### PR DESCRIPTION
Indexed properties work by intercepting property requests and then checking if a self-property exists, or it needs to be sent to an indexer. We never looked up the inheritance chain though, so SuperNodeCollections couldn't be accessed by index.