### PR TITLE
fix: bogus 'empty method' entries in customizer web app

### DIFF
--- a/scripts/1-process/customizer.vue
+++ b/scripts/1-process/customizer.vue
@@ -162,7 +162,9 @@ option inactive-->
                 </div>
               </div>
               <TransitionGroup class="items" name="list-fade" tag="ul">
-                <li v-for="method of klass.methods" v-if="!method">empty method {{ klass.name }}</li>
+                <template v-for="method of klass.methods">
+                  <li v-if="!method">empty method {{ klass.name }}</li>
+                </template>
                 <li
                   v-for="method of klass.methods.filter(
                     x => x.isEnabled || klass.extra.unhideHiddenMethods || !x.meta.isHidden,


### PR DESCRIPTION
![2023-05-30_14-56](https://github.com/ulixee/noderdom/assets/55766834/262bb990-15a2-4a1d-b1cd-c5a13b12b63d)


I have no vue3 experience, but the customizer app is producing bogus 'empty method' entries (the same as the number of valid method klasses). According to the [docs](https://vuejs.org/guide/essentials/list.html#v-for-on-template): 
`When they exist on the same node, v-if has a higher priority than v-for. That means the v-if condition will not have access to variables from the scope of the v-for. This can be fixed by moving v-for to a wrapping <template> tag`